### PR TITLE
Reduce power consumption in DeepSleep

### DIFF
--- a/cores/arduino/wiring.c
+++ b/cores/arduino/wiring.c
@@ -79,12 +79,18 @@ void init( void )
 
   // Clock ADC/DAC for Analog
   PM->APBCMASK.reg |= PM_APBCMASK_ADC | PM_APBCMASK_DAC ;
-
+  
+  /*
+  Commented out to leave pins tri-stated to avoid power consumption
+  in DeepSleep per the following thread:
+  https://github.com/adafruit/Adafruit_SleepyDog/issues/17#issuecomment-481798215
+  
   // Setup all pins (digital and analog) in INPUT mode (default is nothing)
   for (uint32_t ul = 0 ; ul < NUM_DIGITAL_PINS ; ul++ )
   {
     pinMode( ul, INPUT ) ;
   }
+  */
 
   // Initialize Analog Controller
   // Setting clock


### PR DESCRIPTION
Previously, all pins were initialized to INPUT which resulted in higher power draw during DeepSleep; this change comments out that initialization. 

See https://github.com/adafruit/Adafruit_SleepyDog/issues/17#issuecomment-481798215